### PR TITLE
Enable CUDA for ViTs

### DIFF
--- a/deepvision/layers/patching_and_embedding.py
+++ b/deepvision/layers/patching_and_embedding.py
@@ -213,6 +213,7 @@ class __PatchingAndEmbeddingPT(torch.nn.Module):
         self.patch_size = patch_size
         self.input_shape = input_shape
         self.padding = padding
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
         if patch_size < 0:
             raise ValueError(
                 f"The patch_size cannot be a negative number. Received {patch_size}"
@@ -274,7 +275,9 @@ class __PatchingAndEmbeddingPT(torch.nn.Module):
         flattened_shapes = patches_flattened.shape
         class_token_broadcast = self.class_token.expand(flattened_shapes[0], -1, -1)
         patches_flattened = torch.cat([class_token_broadcast, patches_flattened], 1)
-        positions = torch.arange(start=0, end=self.num_patches + 1, step=1)
+        positions = torch.arange(start=0, end=self.num_patches + 1, step=1).to(
+            self.device
+        )
 
         if interpolate and None not in (
             interpolate_width,


### PR DESCRIPTION
`torch.arange()` produced a CPU tensor, which didn't mix well with `torch.nn.Embedding()`.

Closes #30 