### PR TITLE
[FeatureAnalyzer] Support More TF-based outputs

### DIFF
--- a/deepvision/evaluation/feature_analysis.py
+++ b/deepvision/evaluation/feature_analysis.py
@@ -44,7 +44,14 @@ class FeatureAnalyzer:
             print(f"Processing batch {index}/{len(self.dataset)}", end="\r")
             images, labels = batch
 
-            features = self.model(images)["output"]
+            features = self.model(images)
+            # If the output is a `dict` with an `output`
+            # key, such as for Functional Subclassing models
+            # extract the `'output'` key, that all DeepVision models support.
+            # Else - take the `tf.Tensor` output.
+            if isinstance(features, dict):
+                features = features["output"]
+
             all_features.append(features)
             all_classes.append(labels)
 


### PR DESCRIPTION
Functional and subclassing models typically return a `tf.Tensor`, while functional subclassing models typically return a dictionary with a `tf.Tensor` belonging to some key, such as `'output'`. Since all TF-based DeepVision models will be made using functional subclassing, the `FeatureAnalyzer` accepts both formats and either takes the raw output values or obtains the values tied to an `'output'` key in the returned dictionary.

TODO: Should it be customizable which key is queried?