### PR TITLE
Update weight conversion module

### DIFF
--- a/deepvision/models/classification/efficientnet/efficientnet_weight_mapper.py
+++ b/deepvision/models/classification/efficientnet/efficientnet_weight_mapper.py
@@ -181,10 +181,10 @@ def load_tf_to_pt(
     original_filepath = os.path.splitext(filepath)[0]
     torch.save(f"converted_{original_filepath}.pt")
 
-    model.load_state_dict(
+    target_model.load_state_dict(
         torch.load("converted_{original_filepath}.pt"), map_location="cpu"
     )
-    model.to(device)
+    target_model.to(device)
 
     if freeze_bn:
         # Freeze all BatchNorm2d layers

--- a/examples/Weight_Conversion_Example.ipynb
+++ b/examples/Weight_Conversion_Example.ipynb
@@ -1,0 +1,377 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "e7662ef7",
+      "metadata": {
+        "id": "e7662ef7"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install deepvision-toolkit"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "9096c92c",
+      "metadata": {
+        "id": "9096c92c"
+      },
+      "outputs": [],
+      "source": [
+        "import deepvision\n",
+        "import torch\n",
+        "import tensorflow as tf\n",
+        "\n",
+        "config = {\n",
+        "    'batch_size': 32,\n",
+        "    'epochs': 5\n",
+        "}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "e6949482",
+      "metadata": {
+        "id": "e6949482"
+      },
+      "source": [
+        "# Pre-Train on Imagenette using DeepVision and TensorFlow\n",
+        "\n",
+        "To simulate larger-scale pre-training on a dataset such as Imagenet, or a proprietary dataset."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "a9d4c7b8",
+      "metadata": {
+        "id": "a9d4c7b8"
+      },
+      "outputs": [],
+      "source": [
+        "import tensorflow_datasets as tfds\n",
+        "\n",
+        "(train_set, test_set), info = tfds.load(\"imagenette\", \n",
+        "                                           split=[\"train\", \"validation\"],\n",
+        "                                           as_supervised=True, with_info=True)\n",
+        "\n",
+        "class_names = info.features[\"label\"].names\n",
+        "n_classes = info.features[\"label\"].num_classes\n",
+        "\n",
+        "def preprocess_img(img, label):\n",
+        "    img = tf.image.resize(img, (224, 224))\n",
+        "    img = img/255\n",
+        "    return img, label\n",
+        "\n",
+        "train_set = train_set.map(preprocess_img).batch(config['batch_size']).prefetch(tf.data.AUTOTUNE)\n",
+        "test_set = test_set.map(preprocess_img).batch(config['batch_size'], drop_remainder=True).prefetch(tf.data.AUTOTUNE)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "4dd051d5",
+      "metadata": {
+        "id": "4dd051d5"
+      },
+      "outputs": [],
+      "source": [
+        "tf_model = deepvision.models.EfficientNetV2B0(include_top=True,\n",
+        "                                       classes=10,\n",
+        "                                       input_shape=(224, 224, 3),\n",
+        "                                       backend='tensorflow')\n",
+        "\n",
+        "tf_model.compile(\n",
+        "  loss=tf.keras.losses.SparseCategoricalCrossentropy(),\n",
+        "  optimizer=tf.keras.optimizers.Adam(learning_rate=1e-5),\n",
+        "  metrics=['accuracy']\n",
+        ")\n",
+        "history = tf_model.fit(train_set, epochs=5, validation_data=test_set)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "0bebf67a",
+      "metadata": {
+        "id": "0bebf67a"
+      },
+      "outputs": [],
+      "source": [
+        "tf_model.save('effnet.h5')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "858ae3e0",
+      "metadata": {
+        "id": "858ae3e0"
+      },
+      "source": [
+        "# Transfer TensorFlow Weights to PyTorch\n",
+        "\n",
+        "Using DeepVision models, you can easily pick up a trained checkpoint of a model trained in *either* TensorFlow or PyTorch, and fine-tune with either libraries/ecosystems. Each model comes with its `model_weight_mapper` which exposes a `load()` function, accepting a `filepath` to the trained model, the `origin` library and `target` library.\n",
+        "\n",
+        "You'll need to supply a dummy input in the *origin library's* expected format, and DeepVision will reconstruct the target library's equivalent of the model, with the loaded and converted weights, ready to fine-tune:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "aa714f33",
+      "metadata": {
+        "id": "aa714f33"
+      },
+      "outputs": [],
+      "source": [
+        "from deepvision.models.classification.efficientnet import efficientnet_weight_mapper"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "0736b3e4",
+      "metadata": {
+        "id": "0736b3e4"
+      },
+      "outputs": [],
+      "source": [
+        "dummy_input = tf.random.normal([1, 224, 224, 3])\n",
+        "pt_model = efficientnet_weight_mapper.load(filepath='effnet.h5', \n",
+        "                                           origin='tensorflow', \n",
+        "                                           target='pytorch', \n",
+        "                                           dummy_input=dummy_input)\n",
+        "\n",
+        "# If the top classes differ, you can set them here\n",
+        "pt_model.top_dense = torch.nn.Linear(pt_model.top_dense.in_features, 10)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "424cedef",
+      "metadata": {
+        "id": "424cedef"
+      },
+      "source": [
+        "# Fine-Tune in PyTorch"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "55059f22",
+      "metadata": {
+        "id": "55059f22"
+      },
+      "outputs": [],
+      "source": [
+        "from torchvision import transforms\n",
+        "from torchvision.datasets import CIFAR10\n",
+        "from torch.utils.data import DataLoader\n",
+        "import pytorch_lightning as pl\n",
+        "\n",
+        "device = 'cuda' if torch.cuda.is_available() else 'cpu'\n",
+        "\n",
+        "transform=transforms.Compose([transforms.ToTensor(),\n",
+        "                              transforms.Resize([224, 224])])\n",
+        "\n",
+        "cifar_train = CIFAR10('cifar10', train=True, download=True, transform=transform)\n",
+        "cifar_test = CIFAR10('cifar10', train=False, download=True, transform=transform)\n",
+        "\n",
+        "train_dataloader = DataLoader(cifar_train, batch_size=config['batch_size'], drop_last=True)\n",
+        "val_dataloader = DataLoader(cifar_test, batch_size=config['batch_size'], drop_last=True)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "e3332292",
+      "metadata": {
+        "id": "e3332292"
+      },
+      "outputs": [],
+      "source": [
+        "loss = torch.nn.CrossEntropyLoss()\n",
+        "optimizer = torch.optim.Adam(pt_model.parameters(), 1e-6)\n",
+        "\n",
+        "pt_model.compile(loss=loss, optimizer=optimizer)\n",
+        "trainer = pl.Trainer(accelerator=device, max_epochs=5)\n",
+        "trainer.fit(pt_model, train_dataloader, val_dataloader)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "KXsY_s3ucaM6"
+      },
+      "id": "KXsY_s3ucaM6",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Pre-Train using PyTorch"
+      ],
+      "metadata": {
+        "id": "E8ocd7cgcgSP"
+      },
+      "id": "E8ocd7cgcgSP"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import torch\n",
+        "\n",
+        "from torchvision import transforms\n",
+        "from torchvision.datasets import CIFAR10\n",
+        "from torch.utils.data import DataLoader\n",
+        "import pytorch_lightning as pl\n",
+        "from pytorch_lightning.callbacks import RichProgressBar\n",
+        "\n",
+        "device = 'cuda' if torch.cuda.is_available() else 'cpu'\n",
+        "\n",
+        "transform=transforms.Compose([transforms.ToTensor(),\n",
+        "                              transforms.Resize([224, 224])])\n",
+        "\n",
+        "cifar_train = CIFAR10('cifar10', train=True, download=True, transform=transform)\n",
+        "cifar_test = CIFAR10('cifar10', train=False, download=True, transform=transform)\n",
+        "\n",
+        "train_dataloader = DataLoader(cifar_train, batch_size=config['batch_size'], drop_last=True)\n",
+        "val_dataloader = DataLoader(cifar_test, batch_size=config['batch_size'], drop_last=True)\n",
+        "\n",
+        "pt_model = deepvision.models.EfficientNetV2B0(include_top=True,\n",
+        "                                       classes=10,\n",
+        "                                       input_shape=(3, 224, 224),\n",
+        "                                       backend='pytorch')\n",
+        "\n",
+        "loss = torch.nn.CrossEntropyLoss()\n",
+        "optimizer = torch.optim.Adam(pt_model.parameters(), 1e-5)\n",
+        "\n",
+        "pt_model.compile(loss=loss, optimizer=optimizer)\n",
+        "trainer = pl.Trainer(accelerator=device, max_epochs=config['epochs'])\n",
+        "trainer.fit(pt_model, train_dataloader, val_dataloader)"
+      ],
+      "metadata": {
+        "id": "fcyT9KNwclfB"
+      },
+      "id": "fcyT9KNwclfB",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "torch.save(pt_model.state_dict(), 'effnet.pt')"
+      ],
+      "metadata": {
+        "id": "aOYIG_j8cPKf"
+      },
+      "id": "aOYIG_j8cPKf",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Transfer PyTorch Weights to TensorFlow"
+      ],
+      "metadata": {
+        "id": "XR7-RpzbcqK6"
+      },
+      "id": "XR7-RpzbcqK6"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from deepvision.models.classification.efficientnet import efficientnet_weight_mapper\n",
+        "\n",
+        "dummy_input_torch = torch.ones(1, 3, 224, 224)\n",
+        "kwargs = {'include_top': True, 'classes': 10, 'input_shape':(3, 224, 224)}\n",
+        "tf_model = efficientnet_weight_mapper.load_pt_to_tf(filepath='effnet.pt',\n",
+        "                                architecture='EfficientNetV2B0',\n",
+        "                                kwargs=kwargs,\n",
+        "                                dummy_input=dummy_input_torch)"
+      ],
+      "metadata": {
+        "id": "zZvLTpCvcRDk"
+      },
+      "id": "zZvLTpCvcRDk",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Fine-Tune in TensorFlow"
+      ],
+      "metadata": {
+        "id": "RZRJJS6AcwcP"
+      },
+      "id": "RZRJJS6AcwcP"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import tensorflow_datasets as tfds\n",
+        "import tensorflow as tf\n",
+        "\n",
+        "(train_set, test_set), info = tfds.load(\"imagenette\", \n",
+        "                                           split=[\"train\", \"validation\"],\n",
+        "                                           as_supervised=True, with_info=True)\n",
+        "\n",
+        "class_names = info.features[\"label\"].names\n",
+        "n_classes = info.features[\"label\"].num_classes\n",
+        "\n",
+        "def preprocess_img(img, label):\n",
+        "    img = tf.image.resize(img, (224, 224))\n",
+        "    img = img/255\n",
+        "    return img, label\n",
+        "\n",
+        "train_set = train_set.map(preprocess_img).batch(config['batch_size']).prefetch(tf.data.AUTOTUNE)\n",
+        "test_set = test_set.map(preprocess_img).batch(config['batch_size'], drop_remainder=True).prefetch(tf.data.AUTOTUNE)\n",
+        "\n",
+        "tf_model.compile(\n",
+        "  loss=tf.keras.losses.SparseCategoricalCrossentropy(),\n",
+        "  optimizer=tf.keras.optimizers.Adam(learning_rate=1e-5),\n",
+        "  metrics=['accuracy']\n",
+        ")\n",
+        "history = tf_model.fit(train_set, epochs=5, validation_data=test_set)"
+      ],
+      "metadata": {
+        "id": "Ww66udljcTUR"
+      },
+      "id": "Ww66udljcTUR",
+      "execution_count": null,
+      "outputs": []
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.7.0"
+    },
+    "colab": {
+      "provenance": []
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages
+from setuptools import setup
 
 setup(
     name="deepvision-toolkit",


### PR DESCRIPTION
As noted in: https://discuss.pytorch.org/t/out-of-memory-error-when-resume-training-even-though-my-gpu-is-empty/30757/5
    
Sometimes, on some devices, PyTorch-based networks throw a CUDA OOM when loaded directly on the GPU. To avoid this, we now *save* the model and load it back, mapping to the CPU and then pushing back to the original model device.