### PR TITLE
MiT PatchEmbedding input shape fix

### DIFF
--- a/deepvision/models/classification/mix_transformer/mit_pt.py
+++ b/deepvision/models/classification/mix_transformer/mit_pt.py
@@ -85,7 +85,7 @@ class __MiTPT(pl.LightningModule):
 
         for i in range(self.num_stages):
             patch_embed_layer = OverlappingPatchingAndEmbedding(
-                in_channels=3 if i == 0 else embed_dims[i - 1],
+                in_channels=input_shape.shape[0] if i == 0 else embed_dims[i - 1],
                 out_channels=embed_dims[0] if i == 0 else embed_dims[i],
                 patch_size=7 if i == 0 else 3,
                 stride=4 if i == 0 else 2,

--- a/deepvision/models/classification/mix_transformer/mit_pt.py
+++ b/deepvision/models/classification/mix_transformer/mit_pt.py
@@ -85,7 +85,7 @@ class __MiTPT(pl.LightningModule):
 
         for i in range(self.num_stages):
             patch_embed_layer = OverlappingPatchingAndEmbedding(
-                in_channels=input_shape.shape[0] if i == 0 else embed_dims[i - 1],
+                in_channels=input_shape[0] if i == 0 else embed_dims[i - 1],
                 out_channels=embed_dims[0] if i == 0 else embed_dims[i],
                 patch_size=7 if i == 0 else 3,
                 stride=4 if i == 0 else 2,

--- a/deepvision/models/classification/mix_transformer/mit_tf.py
+++ b/deepvision/models/classification/mix_transformer/mit_tf.py
@@ -70,7 +70,7 @@ class __MiTTF(tf.keras.models.Model):
 
         for i in range(num_stages):
             patch_embed_layer = OverlappingPatchingAndEmbedding(
-                in_channels=input_shape.shape[-1] if i == 0 else embed_dims[i - 1],
+                in_channels=input_shape[-1] if i == 0 else embed_dims[i - 1],
                 out_channels=embed_dims[0] if i == 0 else embed_dims[i],
                 patch_size=7 if i == 0 else 3,
                 stride=4 if i == 0 else 2,

--- a/deepvision/models/classification/mix_transformer/mit_tf.py
+++ b/deepvision/models/classification/mix_transformer/mit_tf.py
@@ -70,7 +70,7 @@ class __MiTTF(tf.keras.models.Model):
 
         for i in range(num_stages):
             patch_embed_layer = OverlappingPatchingAndEmbedding(
-                in_channels=3 if i == 0 else embed_dims[i - 1],
+                in_channels=input_shape.shape[-1] if i == 0 else embed_dims[i - 1],
                 out_channels=embed_dims[0] if i == 0 else embed_dims[i],
                 patch_size=7 if i == 0 else 3,
                 stride=4 if i == 0 else 2,

--- a/deepvision/models/segmentation/segformer/segformer_pt.py
+++ b/deepvision/models/segmentation/segformer/segformer_pt.py
@@ -40,7 +40,8 @@ class __SegFormerPT(pl.LightningModule):
             backend="pytorch",
         )
         self.softmax_output = softmax_output
-        self.acc = torchmetrics.Accuracy(task="multiclass", num_classes=num_classes)
+        if num_classes > 1:
+            self.acc = torchmetrics.Accuracy(task="multiclass", num_classes=num_classes)
 
     def forward(self, x):
         y = self.backbone(x)
@@ -74,14 +75,15 @@ class __SegFormerPT(pl.LightningModule):
             on_epoch=True,
             prog_bar=True,
         )
-        acc = self.acc(outputs, targets)
-        self.log(
-            "acc",
-            acc,
-            on_step=True,
-            on_epoch=True,
-            prog_bar=True,
-        )
+        if self.num_classes > 1:
+            acc = self.acc(outputs, targets)
+            self.log(
+                "acc",
+                acc,
+                on_step=True,
+                on_epoch=True,
+                prog_bar=True,
+            )
         return loss
 
     def validation_step(self, val_batch, batch_idx):
@@ -95,12 +97,13 @@ class __SegFormerPT(pl.LightningModule):
             on_epoch=True,
             prog_bar=True,
         )
-        val_acc = self.acc(outputs, targets)
-        self.log(
-            "val_acc",
-            val_acc,
-            on_step=True,
-            on_epoch=True,
-            prog_bar=True,
-        )
+        if self.num_classes > 1:
+            val_acc = self.acc(outputs, targets)
+            self.log(
+                "val_acc",
+                val_acc,
+                on_step=True,
+                on_epoch=True,
+                prog_bar=True,
+            )
         return loss


### PR DESCRIPTION
The input shape for the first OverlappingPatchingAndEmbedding was set to 3 instead of the arbitrary channels from the input shape of the model